### PR TITLE
Improve the Animation support and add a Sprint mechanic to the Player Controller and fix the TileOutOfBounds script to restore the original bounds to the camera view.

### DIFF
--- a/Assets/Jacob/Controllers/Cam.cs
+++ b/Assets/Jacob/Controllers/Cam.cs
@@ -60,5 +60,13 @@ namespace Jacob.Controllers
 			bound.Encapsulate(tileMapCollider.bounds);
 			CalculateSize(bound);
 		}
+
+		/// <summary>
+		/// Re-calculates the Camera's view using the original tilemap bounds.
+		/// </summary>
+		public void RestoreCameraView()
+		{
+			CalculateSize(tilemap.bounds);
+		}
 	}
 }

--- a/Assets/Jacob/Controllers/Player.cs
+++ b/Assets/Jacob/Controllers/Player.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using Jacob.Data;
 using UnityEngine;
 
 namespace Jacob.Controllers
@@ -14,6 +15,8 @@ namespace Jacob.Controllers
 		public string groundTag;
 
 		[Header("Animation Properties")] public string animationParameter;
+		public AnimationType animationType;
+		public TrackInput inputToTrack;
 
 
 		[Header("On Fire Ability Properties")] public KeyCode onFireAbilityKey;
@@ -54,7 +57,6 @@ namespace Jacob.Controllers
 			TopDownCheck();
 			OnFireAbilityCheck();
 		}
-
 
 		private void FixedUpdate()
 		{
@@ -172,12 +174,29 @@ namespace Jacob.Controllers
 		/// <summary>
 		/// Sets the animationParameter that you set in the script to the _horizontalInput float so you can check
 		/// if you're walking and animate the character by checking if the animationParameter is greater than 0 or
-		/// less than -0.
+		/// less than -0. The Boolean feature also uses the _horizontalInput float but it uses a boolean based on if
+		/// _horizontalInput is greater than 0 or less than -0. It also decides to track either _horizontalInput or
+		/// _verticalInput based on what you set in inputToTrack.
 		/// </summary>
 		private void AnimatorCheck()
 		{
 			if (!_hasAnimator) return;
-			_animator.SetFloat(animationParameter, _horizontalInput);
+
+			var inputType = inputToTrack switch
+			{
+				TrackInput.HorizontalInput => _horizontalInput,
+				TrackInput.VerticalInput => _verticalInput,
+			};
+			
+			switch (animationType)
+			{
+				case AnimationType.Float:
+					_animator.SetFloat(animationParameter, inputType);
+					break;
+				case AnimationType.Boolean:
+					_animator.SetBool(animationParameter, inputType is > 0 or < -0);
+					break;
+			}
 		}
 
 		/// <summary>

--- a/Assets/Jacob/Controllers/TileOutOfBounds.cs
+++ b/Assets/Jacob/Controllers/TileOutOfBounds.cs
@@ -10,6 +10,7 @@ namespace Jacob.Controllers
 		public GameObject followedObject;
 		public TilemapCollider2D colliderToExtendTo;
 		public UnityEvent<TilemapCollider2D> whenObjectOutOfBounds;
+		public UnityEvent whenObjectInBounds;
 
 		private TilemapCollider2D _tileMapCollider;
 		private bool _eventCalled;
@@ -21,9 +22,15 @@ namespace Jacob.Controllers
 
 		private void Update()
 		{
-			if (followedObject.transform.position.y >= _tileMapCollider.bounds.max.y && !_eventCalled)
+			if (colliderToExtendTo.bounds.Contains(followedObject.transform.position) && !_eventCalled)
 			{
 				InvokeEvent();
+			}
+
+			if (_tileMapCollider.bounds.Contains(followedObject.transform.position) && _eventCalled)
+			{
+				whenObjectInBounds.Invoke();
+				_eventCalled = false;
 			}
 		}
 

--- a/Assets/Jacob/Data/AnimationType.cs
+++ b/Assets/Jacob/Data/AnimationType.cs
@@ -1,0 +1,8 @@
+﻿namespace Jacob.Data
+{
+	public enum AnimationType
+	{
+		Float,
+		Boolean
+	}
+}

--- a/Assets/Jacob/Data/AnimationType.cs.meta
+++ b/Assets/Jacob/Data/AnimationType.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 43298b87d77f4ba68570599d733c1938
+timeCreated: 1679599287

--- a/Assets/Jacob/Data/TrackInput.cs
+++ b/Assets/Jacob/Data/TrackInput.cs
@@ -1,0 +1,8 @@
+﻿namespace Jacob.Data
+{
+	public enum TrackInput
+	{
+		HorizontalInput,
+		VerticalInput
+	}
+}

--- a/Assets/Jacob/Data/TrackInput.cs.meta
+++ b/Assets/Jacob/Data/TrackInput.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 53a119d0bd1a420aa90aec58fb01cf21
+timeCreated: 1679599638

--- a/Assets/Jacob/IkeaAd.unity
+++ b/Assets/Jacob/IkeaAd.unity
@@ -4474,10 +4474,12 @@ MonoBehaviour:
   groundTag: 
   animationParameter: 
   animationType: 0
-  _inputToTrack: 0
+  inputToTrack: 0
   onFireAbilityKey: 0
   onFireAbilityUnlocked: 0
   onFireTimer: 0
+  maxMoveSpeed: 10
+  secondsUntilFullSprint: 2
 --- !u!50 &1408095790
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/Jacob/IkeaAd.unity
+++ b/Assets/Jacob/IkeaAd.unity
@@ -4473,6 +4473,8 @@ MonoBehaviour:
   checkForGround: 0
   groundTag: 
   animationParameter: 
+  animationType: 0
+  _inputToTrack: 0
   onFireAbilityKey: 0
   onFireAbilityUnlocked: 0
   onFireTimer: 0

--- a/Assets/Jacob/IkeaAd.unity
+++ b/Assets/Jacob/IkeaAd.unity
@@ -4435,6 +4435,21 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  whenObjectInBounds:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 346523137}
+        m_TargetAssemblyTypeName: Jacob.Controllers.Cam, Assembly-CSharp
+        m_MethodName: RestoreCameraView
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &1408095788
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Rose/Scripts/TimerClockController.cs
+++ b/Assets/Rose/Scripts/TimerClockController.cs
@@ -40,7 +40,7 @@ public class TimerClockController : MonoBehaviour
         {
             IsAnimationOver = false;
         } 
-       different idea to fix this */ 
+       /*different idea to fix this */ 
       while(loopCount >= 0)
         {
             new WaitForSeconds(1);


### PR DESCRIPTION
This pull request improves the Player Controller by improving the Animation support so the Animation support can either bind to floats or bools. I also added a Sprint mechanic to the Player Controller that accelerates your player when you press the Shift key in an amount of seconds you set to a max move speed you set.

I also fixed the TileOutOfBounds script by using the `Contains()` method which works a lot better then just manually checking operators because this means it will work if you have a different position for the bounds you want to extend you that aren't just left of your original bounds. I also added code that restores the original camera bounds when you re enter the original bounds, also checked by the `Contains()` method.