### PR TITLE
Add Incorrect Object Position to the Sockets script.

### DIFF
--- a/Assets/Jacob/Scenes/TestScene14.unity
+++ b/Assets/Jacob/Scenes/TestScene14.unity
@@ -1504,6 +1504,8 @@ MonoBehaviour:
   onFireAbilityKey: 0
   onFireAbilityUnlocked: 0
   onFireTimer: 0
+  _animator: {fileID: 0}
+  IsWalking: 0
 --- !u!50 &1137033548
 Rigidbody2D:
   serializedVersion: 4
@@ -1902,12 +1904,20 @@ MonoBehaviour:
   sockets:
   - socket: {fileID: 632292055}
     correctGameObject: {fileID: 315917587}
+    incorrectObjectPosition: {x: 8, y: 10}
+    overrideDefaultProtection: 0
   - socket: {fileID: 1016575196}
     correctGameObject: {fileID: 428565551}
+    incorrectObjectPosition: {x: 0, y: 0}
+    overrideDefaultProtection: 0
   - socket: {fileID: 2022081935}
     correctGameObject: {fileID: 1433215481}
+    incorrectObjectPosition: {x: 0, y: 0}
+    overrideDefaultProtection: 0
   - socket: {fileID: 626809943}
     correctGameObject: {fileID: 303329537}
+    incorrectObjectPosition: {x: 0, y: 0}
+    overrideDefaultProtection: 0
   onAllSocketsCorrect:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Jacob/Scripts/Controllers/DragAndDrop.cs
+++ b/Assets/Jacob/Scripts/Controllers/DragAndDrop.cs
@@ -7,17 +7,19 @@ namespace Jacob.Scripts.Controllers
 	public class DragAndDrop : MonoBehaviour
 	{
 		[NonSerialized] public bool IsBeingHeld;
-
+		[NonSerialized] public Rigidbody2D Rigidbody;
+		[NonSerialized] public Collider2D Collider2D;
+		
 		private Camera _camera;
 		private Vector3 MouseWorldPos => _camera.ScreenToWorldPoint(Input.mousePosition);
 		private Vector3 _mousePositionOffset;
-		private Rigidbody2D _rigidbody;
 		private bool _isDraggable = true;
 
 		private void Awake()
 		{
 			_camera = Camera.main;
-			TryGetComponent(out _rigidbody);
+			TryGetComponent(out Rigidbody);
+			TryGetComponent(out Collider2D);
 		}
 
 		private void OnMouseDown()
@@ -37,8 +39,8 @@ namespace Jacob.Scripts.Controllers
 		{
 			if (!_isDraggable) return;
 			IsBeingHeld = false;
-			if (!_rigidbody) return;
-			_rigidbody.velocity = new Vector2(0,0);
+			if (!Rigidbody) return;
+			Rigidbody.velocity = new Vector2(0,0);
 		}
 
 		public void DisableDragging()

--- a/Assets/Jacob/Scripts/Controllers/Player.cs
+++ b/Assets/Jacob/Scripts/Controllers/Player.cs
@@ -51,15 +51,13 @@ namespace Jacob.Scripts.Controllers
 			GetComponents();
 			SetupRigidbody();
 			RecordBaseStats();
-
-
 		}
 
 		private void Update()
 		{
 			//Animator Declarations
-			_animator.SetBool("IsJumping", _canJump);
-			_animator.SetBool("IsWalking", IsWalking);
+			// _animator.SetBool("IsJumping", _canJump);
+			// _animator.SetBool("IsWalking", IsWalking);
 
 			if (_canControlMovement)
 			{

--- a/Assets/Jacob/Scripts/Controllers/Socket.cs
+++ b/Assets/Jacob/Scripts/Controllers/Socket.cs
@@ -68,14 +68,14 @@ namespace Jacob.Scripts.Controllers
 
 		private void SocketObject(DragAndDrop obj)
 		{
-			if (obj.TryGetComponent<BoxCollider2D>(out var collider))
+			if (obj.Collider2D)
 			{
-				collider.isTrigger = true;
+				obj.Collider2D.isTrigger = true;
 			}
 			
-			if (obj.TryGetComponent<Rigidbody2D>(out var rigidBody2D))
+			if (obj.Rigidbody)
 			{
-				rigidBody2D.isKinematic = true;
+				obj.Rigidbody.isKinematic = true;
 			}
 
 			heldObject = obj.gameObject;

--- a/Assets/Jacob/Scripts/Controllers/Sockets.cs
+++ b/Assets/Jacob/Scripts/Controllers/Sockets.cs
@@ -6,7 +6,7 @@ using UnityEngine.Events;
 
 namespace Jacob.Scripts.Controllers
 {
-	public class Sockets: MonoBehaviour
+	public class Sockets : MonoBehaviour
 	{
 		public SocketsSocket[] sockets;
 		public UnityEvent onAllSocketsCorrect;
@@ -24,8 +24,33 @@ namespace Jacob.Scripts.Controllers
 
 		private static void EnterSocket(SocketsSocket socketsSocket)
 		{
-			if (socketsSocket.socket.heldObject != socketsSocket.correctGameObject) return;
-			socketsSocket.Correct = true;
+			if (socketsSocket.socket.heldObject != socketsSocket.correctGameObject)
+			{
+				if (!socketsSocket.socket.heldObject.TryGetComponent<DragAndDrop>(out var drop)) return;
+
+				drop.transform.parent = null;
+
+				if (drop.Collider2D)
+				{
+					drop.Collider2D.isTrigger = false;
+				}
+
+				if (drop.Rigidbody)
+				{
+					drop.Rigidbody.isKinematic = false;
+				}
+
+				drop.EnableDragging();
+
+				if (!socketsSocket.overrideDefaultProtection &&
+				    socketsSocket.incorrectObjectPosition == Vector2.zero) return;
+
+				drop.transform.position = socketsSocket.incorrectObjectPosition;
+			}
+			else
+			{
+				socketsSocket.Correct = true;
+			}
 		}
 
 		private IEnumerator AllCorrectCoroutine()
@@ -34,7 +59,7 @@ namespace Jacob.Scripts.Controllers
 			{
 				yield return new WaitForEndOfFrame();
 			}
-			
+
 			print("all are correct");
 			onAllSocketsCorrect?.Invoke();
 		}

--- a/Assets/Jacob/Scripts/Data/SocketsSocket.cs
+++ b/Assets/Jacob/Scripts/Data/SocketsSocket.cs
@@ -9,6 +9,8 @@ namespace Jacob.Scripts.Data
 	{
 		public Socket socket;
 		public GameObject correctGameObject;
+		public Vector2 incorrectObjectPosition;
+		public bool overrideDefaultProtection;
 		[NonSerialized] public bool Correct;
 	}
 }

--- a/Assets/Jacob/Scripts/Editor/SocketsSocketDrawer.cs
+++ b/Assets/Jacob/Scripts/Editor/SocketsSocketDrawer.cs
@@ -1,0 +1,122 @@
+using Jacob.Scripts.Data;
+using UnityEditor;
+using UnityEngine;
+
+namespace Jacob.Scripts.Editor
+{
+	[CustomPropertyDrawer(typeof(SocketsSocket))]
+	public class SocketsSocketDrawer : PropertyDrawer
+	{
+		private SerializedProperty _socket;
+		private SerializedProperty _correctGameObject;
+		private SerializedProperty _incorrectObjectPosition;
+		private SerializedProperty _overrideDefaultProtection;
+		private int _totalLines = 1;
+		
+		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+		{
+			EditorGUI.BeginProperty(position, label, property);
+			GetProperties(property);
+			var foldoutBox = new Rect(position.min.x, position.min.y, position.size.x,
+				EditorGUIUtility.singleLineHeight);
+			property.isExpanded = EditorGUI.Foldout(foldoutBox, property.isExpanded, label);
+			if (property.isExpanded)
+			{
+				DrawSocketField(position);
+				DrawCorrectGameObjectField(position);
+				DrawIncorrectObjectPositionField(position);
+				if (_incorrectObjectPosition.vector2Value == Vector2.zero)
+				{
+					DrawOverrideLabel(position);
+					DrawOverrideButton(position);
+				}
+			}
+
+			EditorGUI.EndProperty();
+		}
+
+
+		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		{
+			GetProperties(property);
+			
+			var lineHeight = EditorGUIUtility.singleLineHeight;
+			_totalLines = 1;
+			
+			if (property.isExpanded)
+			{
+				if (_incorrectObjectPosition.vector2Value == Vector2.zero) _totalLines += 3;
+				_totalLines += 3;
+			}
+
+			return lineHeight * _totalLines;
+		}
+
+		private void GetProperties(SerializedProperty property)
+		{
+			_socket = property.FindPropertyRelative("socket");
+			_correctGameObject = property.FindPropertyRelative("correctGameObject");
+			_incorrectObjectPosition = property.FindPropertyRelative("incorrectObjectPosition");
+			_overrideDefaultProtection = property.FindPropertyRelative("overrideDefaultProtection");
+		}
+
+		private void DrawSocketField(Rect position)
+		{
+			var singleLineHeight = EditorGUIUtility.singleLineHeight;
+			var posX = position.min.x;
+			var posY = position.min.y + singleLineHeight;
+			var width = position.size.x;
+
+			var drawArea = new Rect(posX, posY, width, singleLineHeight);
+			EditorGUI.PropertyField(drawArea, _socket, new GUIContent("Socket"));
+		}
+
+		private void DrawCorrectGameObjectField(Rect position)
+		{
+			var singleLineHeight = EditorGUIUtility.singleLineHeight;
+			var posX = position.min.x;
+			var posY = position.min.y + singleLineHeight * 2;
+			var width = position.size.x;
+
+			var drawArea = new Rect(posX, posY, width, singleLineHeight);
+			EditorGUI.PropertyField(drawArea, _correctGameObject, new GUIContent("Correct GameObject"));
+		}
+
+		private void DrawIncorrectObjectPositionField(Rect position)
+		{
+			var singleLineHeight = EditorGUIUtility.singleLineHeight;
+			var posX = position.min.x;
+			var posY = position.min.y + singleLineHeight * 3;
+			var width = position.size.x;
+
+			var drawArea = new Rect(posX, posY, width, singleLineHeight);
+			EditorGUI.PropertyField(drawArea, _incorrectObjectPosition, new GUIContent("Incorrect Object Position"));
+		}
+
+		private void DrawOverrideLabel(Rect position)
+		{
+			var singleLineHeight = EditorGUIUtility.singleLineHeight;
+			var posX = position.min.x;
+			var posY = position.min.y + singleLineHeight * 4;
+			var width = position.size.x;
+
+			var drawArea = new Rect(posX, posY, width, singleLineHeight * 2);
+			EditorGUI.HelpBox(drawArea,
+				"By default, "+"if your Incorrect Object Position is <0, 0>, "+
+				"the Sockets script won't teleport your Object.\n" +
+				"Press the Override toggle below to override this protection.", MessageType.Info);
+		}
+
+		private void DrawOverrideButton(Rect position)
+		{
+			var singleLineHeight = EditorGUIUtility.singleLineHeight;
+			var posX = position.min.x;
+			var posY = position.min.y + singleLineHeight * 6;
+			var width = position.size.x;
+
+			var drawArea = new Rect(posX, posY, width, singleLineHeight);
+			EditorGUI.PropertyField(drawArea, _overrideDefaultProtection,
+				new GUIContent("Override Default Protection"));
+		}
+	}
+}

--- a/Assets/Jacob/Scripts/Editor/SocketsSocketDrawer.cs.meta
+++ b/Assets/Jacob/Scripts/Editor/SocketsSocketDrawer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3714257efd924a60a8b5d5f7f6b5112f
+timeCreated: 1681537197


### PR DESCRIPTION
This commit adds the Incorrect Object Position feature to the Sockets script letting you teleport the Object you put into the Socket if its not the Object you set in the Correct GameObject field. By default, if you have the Incorrect Object Position to <0, 0>, no teleporting will happen. You can override that with a toggle.