### PR TITLE
Improve the Debug Menu and make some abstractions.

### DIFF
--- a/Assets/Danny/scripts/ChangeScene.cs
+++ b/Assets/Danny/scripts/ChangeScene.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+
 public class ChangeScene : MonoBehaviour
 {
     public string SceneName;

--- a/Assets/Jacob/Scenes/TestScene14.unity
+++ b/Assets/Jacob/Scenes/TestScene14.unity
@@ -792,6 +792,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  ads: []
 --- !u!4 &454288596
 Transform:
   m_ObjectHideFlags: 0
@@ -1494,6 +1495,8 @@ MonoBehaviour:
   jumpForce: 10
   moveSpeed: 10
   topDown: 0
+  flipWhenTurningDirection: 0
+  enableSprinting: 0
   maxMoveSpeed: 0
   secondsUntilFullSprint: 0
   checkForGround: 0
@@ -1501,11 +1504,10 @@ MonoBehaviour:
   animationParameter: 
   animationType: 0
   inputToTrack: 0
+  jumpingAnimationParameter: 
   onFireAbilityKey: 0
   onFireAbilityUnlocked: 0
   onFireTimer: 0
-  _animator: {fileID: 0}
-  IsWalking: 0
 --- !u!50 &1137033548
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/Jacob/Scripts/Controllers/ActivateDeactivate.cs
+++ b/Assets/Jacob/Scripts/Controllers/ActivateDeactivate.cs
@@ -27,7 +27,7 @@ namespace Jacob.Scripts.Controllers
 
 		private void OnTriggerEnter2D(Collider2D col)
 		{
-			if (!collideToTrigger && !_hasCollider);
+			if (!collideToTrigger && !_hasCollider) return;
 			if (!col.CompareTag("Player")) return;
 			Activate();
 			Deactivate();
@@ -41,7 +41,7 @@ namespace Jacob.Scripts.Controllers
 			if (activate.Count <= 0) return;
 			foreach (var o in activate)
 			{
-				o.SetActive(true);
+				o?.SetActive(true);
 			}
 		}
 
@@ -53,7 +53,7 @@ namespace Jacob.Scripts.Controllers
 			if (deactivate.Count <= 0) return;
 			foreach (var o in deactivate)
 			{
-				o.SetActive(false);
+				o?.SetActive(false);
 			}
 		}
 	}

--- a/Assets/Jacob/Scripts/Controllers/DebugMenu.cs
+++ b/Assets/Jacob/Scripts/Controllers/DebugMenu.cs
@@ -16,6 +16,7 @@ namespace Jacob.Scripts.Controllers
 		private Dictionary<int, GameObject> _indexToGameObject;
 		private int _selectedOption;
 		private GameManager _gameManager;
+		private GameObject _player;
 
 		public void InitializeMenu()
 		{
@@ -32,6 +33,7 @@ namespace Jacob.Scripts.Controllers
 			var optionData = Ads.Select(ad => new TMP_Dropdown.OptionData { text = ad.adName }).ToList();
 			_dropdown.options = optionData;
 			_gameManager = GameManager.Get();
+			_player = GameObject.FindWithTag("Player");
 		}
 
 		private void Update()
@@ -64,7 +66,12 @@ namespace Jacob.Scripts.Controllers
 		{
 			if (Ads.Count == 0) return;
 			_gameManager.CurrentlyActiveScene.SetActive(false);
-			_indexToGameObject[_selectedOption].gameObject.SetActive(true);
+			
+			var chosenObj = _indexToGameObject[_selectedOption].gameObject;
+			var debugSupport = chosenObj.GetComponent<DebugSupport>();
+			chosenObj.SetActive(true);
+			_player.transform.position = debugSupport.locationToTeleportTo;
+			
 			Exit();
 		}
 	}

--- a/Assets/Jacob/Scripts/Controllers/DebugSupport.cs
+++ b/Assets/Jacob/Scripts/Controllers/DebugSupport.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+namespace Jacob.Scripts.Controllers
+{
+	public class DebugSupport : MonoBehaviour
+	{
+		public Vector2 locationToTeleportTo;
+		private GameManager _gameManager;
+
+		private void Awake()
+		{
+			_gameManager = GameManager.Get();
+			_gameManager.SetActiveScene(gameObject);
+		}
+
+		private void OnEnable()
+		{
+			_gameManager.SetActiveScene(gameObject);
+		}
+
+		private void OnDisable()
+		{
+			_gameManager.ClearActiveScene();
+		}
+	}
+}

--- a/Assets/Jacob/Scripts/Controllers/DebugSupport.cs.meta
+++ b/Assets/Jacob/Scripts/Controllers/DebugSupport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f177b7067e55f1d20b9c530e73b6b206
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Jacob/Scripts/Data/DrawerFieldLines.cs
+++ b/Assets/Jacob/Scripts/Data/DrawerFieldLines.cs
@@ -1,0 +1,8 @@
+namespace Jacob.Scripts.Data
+{
+	public abstract class DrawerFieldLines
+	{
+		public const int PropertyField = 1;
+		public const int HelpBox = 2;
+	}
+}

--- a/Assets/Jacob/Scripts/Data/DrawerFieldLines.cs.meta
+++ b/Assets/Jacob/Scripts/Data/DrawerFieldLines.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 13d18a7f20e54a53ac77d876c298b08a
+timeCreated: 1681958112

--- a/Assets/Jacob/Scripts/Data/DrawerRectValues.cs
+++ b/Assets/Jacob/Scripts/Data/DrawerRectValues.cs
@@ -1,0 +1,11 @@
+using UnityEditor;
+
+namespace Jacob.Scripts.Data
+{
+	public struct DrawerRectValues
+	{
+		public float posX;
+		public float posY;
+		public float width;
+	}
+}

--- a/Assets/Jacob/Scripts/Data/DrawerRectValues.cs.meta
+++ b/Assets/Jacob/Scripts/Data/DrawerRectValues.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0c542c4a89d2420ea6b2e7c3e7e80477
+timeCreated: 1681956427

--- a/Assets/Jacob/Scripts/Editor/DebugAdDrawer.cs
+++ b/Assets/Jacob/Scripts/Editor/DebugAdDrawer.cs
@@ -1,0 +1,43 @@
+using System;
+using Jacob.Scripts.Controllers;
+using Jacob.Scripts.Data;
+using UnityEditor;
+using UnityEngine;
+
+namespace Jacob.Scripts.Editor
+{
+	[CustomPropertyDrawer(typeof(DebugAd))]
+	public class DebugAdDrawer : Drawer
+	{
+		private const string DebugSupportErrorMessage = "Your GameObject doesn't have the DebugSupport script. " +
+		                                                "This is required for the functionality of the Debug Menu to " +
+		                                                "work on that specific GameObject.";
+		
+		protected override void AllocateLines(SerializedProperty property)
+		{
+			AllocateLines(DrawerFieldLines.PropertyField);
+			AllocateLines(DrawerFieldLines.PropertyField);
+
+			var adObj = property.FindPropertyRelative("adObject");
+			var adObjGameObject = adObj.objectReferenceValue as GameObject;
+			
+			if (adObjGameObject && !adObjGameObject.TryGetComponent<DebugSupport>(out _))
+			{
+				AllocateLines(DrawerFieldLines.HelpBox);
+			}
+		}
+
+		protected override void GUICode(Rect position, SerializedProperty property)
+		{
+			var adObj = property.FindPropertyRelative("adObject");
+			var adName = PropertyField(position, property.FindPropertyRelative("adName"), "Ad Name", 1);
+			var adObject = PropertyField(position, adObj, "Ad Object", adName);
+
+			var adObjGameObject = adObj.objectReferenceValue as GameObject;
+			if (adObjGameObject && !adObjGameObject.TryGetComponent<DebugSupport>(out _))
+			{
+				HelpBox(position, DebugSupportErrorMessage, MessageType.Error, adObject);
+			}
+		}
+	}
+}

--- a/Assets/Jacob/Scripts/Editor/DebugAdDrawer.cs.meta
+++ b/Assets/Jacob/Scripts/Editor/DebugAdDrawer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3cc4db776ba840d9acb5d8ffd2cf5eb4
+timeCreated: 1681956881

--- a/Assets/Jacob/Scripts/Editor/Drawer.cs
+++ b/Assets/Jacob/Scripts/Editor/Drawer.cs
@@ -1,0 +1,80 @@
+using System;
+using Jacob.Scripts.Data;
+using UnityEditor;
+using UnityEngine;
+
+namespace Jacob.Scripts.Editor
+{
+	public class Drawer : PropertyDrawer
+	{
+		private int _totalLines;
+		private readonly float _lineHeight = EditorGUIUtility.singleLineHeight;
+
+		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		{
+			_totalLines = 1;
+			if (!property.isExpanded) return _lineHeight * _totalLines;
+			AllocateLines(property);
+			return _lineHeight * _totalLines;
+		}
+
+		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+		{
+			EditorGUI.BeginProperty(position, label, property);
+			FoldOutCode(position, property, label);
+			if (property.isExpanded)
+			{
+				GUICode(position, property);
+			}
+
+			EditorGUI.EndProperty();
+		}
+
+		private void FoldOutCode(Rect position, SerializedProperty property, GUIContent label)
+		{
+			var foldoutBox = new Rect(position.min.x, position.min.y, position.size.x, _lineHeight);
+			property.isExpanded = EditorGUI.Foldout(foldoutBox, property.isExpanded, label);
+		}
+
+		protected virtual void GUICode(Rect position, SerializedProperty property)
+		{
+			throw new NotImplementedException();
+		}
+
+		protected int PropertyField(Rect position, SerializedProperty property, string label, int currentLine)
+		{
+			var rectValues = RectValues(position, currentLine);
+			var drawArea = new Rect(rectValues.posX, rectValues.posY, rectValues.width, _lineHeight);
+			EditorGUI.PropertyField(drawArea, property, new GUIContent(label));
+			return currentLine + DrawerFieldLines.PropertyField;
+		}
+
+		protected int HelpBox(Rect position, string message, MessageType messageType, int currentLine)
+		{
+			var rectValues = RectValues(position, currentLine);
+			var drawArea = new Rect(rectValues.posX, rectValues.posY, rectValues.width, _lineHeight * 2);
+			EditorGUI.HelpBox(drawArea, message, messageType);
+			return currentLine + DrawerFieldLines.HelpBox;
+		}
+
+		protected virtual void AllocateLines(SerializedProperty property)
+		{
+			throw new NotImplementedException();
+		}
+
+		protected void AllocateLines(int lineAmount)
+		{
+			_totalLines += lineAmount;
+		}
+
+		private DrawerRectValues RectValues(Rect position, int currentLine)
+		{
+			return new DrawerRectValues
+			{
+				posX = position.min.x,
+				posY = position.min.y + _lineHeight * currentLine,
+				width = position.size.x
+			};
+		}
+	}
+}

--- a/Assets/Jacob/Scripts/Editor/Drawer.cs.meta
+++ b/Assets/Jacob/Scripts/Editor/Drawer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 96893ca0f0104825b93650bd394f933a
+timeCreated: 1681955760

--- a/Assets/Jacob/Scripts/Editor/GameManagerEditor.cs
+++ b/Assets/Jacob/Scripts/Editor/GameManagerEditor.cs
@@ -9,9 +9,11 @@ namespace Jacob.Scripts.Editor
 	{
 		public override void OnInspectorGUI()
 		{
-			base.OnInspectorGUI();
-
 			var script = target as GameManager;
+
+			EditorGUILayout.LabelField("Health Properties", EditorStyles.boldLabel);
+			script.maxHealth = EditorGUILayout.DoubleField("Max Health", script.maxHealth);
+			EditorGUILayout.PropertyField(serializedObject.FindProperty("whenYouDie"));
 
 			EditorGUILayout.LabelField("Currency Properties", EditorStyles.boldLabel);
 			script.returnType = (GameManagerReturnType)EditorGUILayout.EnumPopup("Return Type", script.returnType);
@@ -24,6 +26,8 @@ namespace Jacob.Scripts.Editor
 					EditorGUILayout.PropertyField(serializedObject.FindProperty("whenMoneyChangesString"));
 					break;
 			}
+
+			EditorGUILayout.PropertyField(serializedObject.FindProperty("ads"));
 
 			serializedObject.ApplyModifiedProperties();
 			Utilities.CheckIfGUIChanged(script);

--- a/Assets/Jacob/Scripts/Editor/SocketsSocketDrawer.cs
+++ b/Assets/Jacob/Scripts/Editor/SocketsSocketDrawer.cs
@@ -5,118 +5,37 @@ using UnityEngine;
 namespace Jacob.Scripts.Editor
 {
 	[CustomPropertyDrawer(typeof(SocketsSocket))]
-	public class SocketsSocketDrawer : PropertyDrawer
+	public class SocketsSocketDrawer : Drawer
 	{
-		private SerializedProperty _socket;
-		private SerializedProperty _correctGameObject;
-		private SerializedProperty _incorrectObjectPosition;
-		private SerializedProperty _overrideDefaultProtection;
-		private int _totalLines = 1;
-		
-		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
-		{
-			EditorGUI.BeginProperty(position, label, property);
-			GetProperties(property);
-			var foldoutBox = new Rect(position.min.x, position.min.y, position.size.x,
-				EditorGUIUtility.singleLineHeight);
-			property.isExpanded = EditorGUI.Foldout(foldoutBox, property.isExpanded, label);
-			if (property.isExpanded)
-			{
-				DrawSocketField(position);
-				DrawCorrectGameObjectField(position);
-				DrawIncorrectObjectPositionField(position);
-				if (_incorrectObjectPosition.vector2Value == Vector2.zero)
-				{
-					DrawOverrideLabel(position);
-					DrawOverrideButton(position);
-				}
-			}
+		private const string OverrideWarning = "By default, " + "if your Incorrect Object Position is <0, 0>, " +
+		                                       "the Sockets script won't teleport your Object.\n" +
+		                                       "Press the Override toggle below to override this protection.";
 
-			EditorGUI.EndProperty();
+		protected override void AllocateLines(SerializedProperty property)
+		{
+			var incorrectObjectPosition = property.FindPropertyRelative("incorrectObjectPosition");
+
+			AllocateLines(DrawerFieldLines.PropertyField);
+			AllocateLines(DrawerFieldLines.PropertyField);
+			AllocateLines(DrawerFieldLines.PropertyField);
+			if (incorrectObjectPosition.vector2Value != Vector2.zero) return;
+			AllocateLines(DrawerFieldLines.HelpBox);
+			AllocateLines(DrawerFieldLines.PropertyField);
 		}
 
-
-		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		protected override void GUICode(Rect position, SerializedProperty property)
 		{
-			GetProperties(property);
+			var incorrectObj = property.FindPropertyRelative("incorrectObjectPosition");
 			
-			var lineHeight = EditorGUIUtility.singleLineHeight;
-			_totalLines = 1;
-			
-			if (property.isExpanded)
-			{
-				if (_incorrectObjectPosition.vector2Value == Vector2.zero) _totalLines += 3;
-				_totalLines += 3;
-			}
-
-			return lineHeight * _totalLines;
-		}
-
-		private void GetProperties(SerializedProperty property)
-		{
-			_socket = property.FindPropertyRelative("socket");
-			_correctGameObject = property.FindPropertyRelative("correctGameObject");
-			_incorrectObjectPosition = property.FindPropertyRelative("incorrectObjectPosition");
-			_overrideDefaultProtection = property.FindPropertyRelative("overrideDefaultProtection");
-		}
-
-		private void DrawSocketField(Rect position)
-		{
-			var singleLineHeight = EditorGUIUtility.singleLineHeight;
-			var posX = position.min.x;
-			var posY = position.min.y + singleLineHeight;
-			var width = position.size.x;
-
-			var drawArea = new Rect(posX, posY, width, singleLineHeight);
-			EditorGUI.PropertyField(drawArea, _socket, new GUIContent("Socket"));
-		}
-
-		private void DrawCorrectGameObjectField(Rect position)
-		{
-			var singleLineHeight = EditorGUIUtility.singleLineHeight;
-			var posX = position.min.x;
-			var posY = position.min.y + singleLineHeight * 2;
-			var width = position.size.x;
-
-			var drawArea = new Rect(posX, posY, width, singleLineHeight);
-			EditorGUI.PropertyField(drawArea, _correctGameObject, new GUIContent("Correct GameObject"));
-		}
-
-		private void DrawIncorrectObjectPositionField(Rect position)
-		{
-			var singleLineHeight = EditorGUIUtility.singleLineHeight;
-			var posX = position.min.x;
-			var posY = position.min.y + singleLineHeight * 3;
-			var width = position.size.x;
-
-			var drawArea = new Rect(posX, posY, width, singleLineHeight);
-			EditorGUI.PropertyField(drawArea, _incorrectObjectPosition, new GUIContent("Incorrect Object Position"));
-		}
-
-		private void DrawOverrideLabel(Rect position)
-		{
-			var singleLineHeight = EditorGUIUtility.singleLineHeight;
-			var posX = position.min.x;
-			var posY = position.min.y + singleLineHeight * 4;
-			var width = position.size.x;
-
-			var drawArea = new Rect(posX, posY, width, singleLineHeight * 2);
-			EditorGUI.HelpBox(drawArea,
-				"By default, "+"if your Incorrect Object Position is <0, 0>, "+
-				"the Sockets script won't teleport your Object.\n" +
-				"Press the Override toggle below to override this protection.", MessageType.Info);
-		}
-
-		private void DrawOverrideButton(Rect position)
-		{
-			var singleLineHeight = EditorGUIUtility.singleLineHeight;
-			var posX = position.min.x;
-			var posY = position.min.y + singleLineHeight * 6;
-			var width = position.size.x;
-
-			var drawArea = new Rect(posX, posY, width, singleLineHeight);
-			EditorGUI.PropertyField(drawArea, _overrideDefaultProtection,
-				new GUIContent("Override Default Protection"));
+			var socket = PropertyField(position, property.FindPropertyRelative("socket"), "Socket", 1);
+			var correctGameObject = PropertyField(position, property.FindPropertyRelative("correctGameObject"),
+				"Correct GameObject", socket);
+			var incorrectObjectPosition =
+				PropertyField(position, incorrectObj, "Incorrect Object Position", correctGameObject);
+			if (incorrectObj.vector2Value != Vector2.zero) return;
+			var overrideWarning = HelpBox(position, OverrideWarning, MessageType.Warning, incorrectObjectPosition);
+			PropertyField(position, property.FindPropertyRelative("overrideDefaultProtection"),
+				"Override Default Protection", overrideWarning);
 		}
 	}
 }


### PR DESCRIPTION
This commit improves the Debug Menu by making a script called DebugSupport which you attach to your Ad Objects and you put where you want the Player to teleport to and the script will handle all of the settings the Active Scene in the GameManager. The GameManager Ad list will warn you if you don't have a DebugSupport script on the GameObject you put in there.

I also added some internal abstractions for Editor stuff.